### PR TITLE
feat: add shared ButtonBack component and integrate across pages

### DIFF
--- a/src/features/applications/hooks/useGetMyApplication.ts
+++ b/src/features/applications/hooks/useGetMyApplication.ts
@@ -7,7 +7,7 @@ import { useState } from "react";
 export const useGetMyApplications = (initialParams?: GetMyApplicationsParams) => {
   const [params, setParams] = useState<GetMyApplicationsParams>({
     page: 1,
-    pageSize: 10,
+    pageSize: 6,
     sortBy: "appliedAt",
     sortOrder: "desc",
     ...initialParams,

--- a/src/features/applications/pages/ApplicationDetailPage.tsx
+++ b/src/features/applications/pages/ApplicationDetailPage.tsx
@@ -15,6 +15,7 @@ import type {
   ApplicationStatusLabel,
   ApplicationStatusValue,
 } from "../types/application.type";
+import { ButtonBack } from "@/shared/components/ui/ButtonBack";
 
 export const ApplicationDetailPage = () => {
   const { applicationId } = useParams<{ applicationId: string }>();
@@ -57,12 +58,7 @@ export const ApplicationDetailPage = () => {
   return (
     <Section>
       <Container>
-        <button
-          onClick={() => navigate(-1)}
-          className="flex items-center text-sm text-text-secondary hover:text-primary mb-6"
-        >
-          <ChevronLeft className="w-4 h-4 mr-1" /> Quay lại
-        </button>
+        <ButtonBack className="!mb-5">Quay lại danh sách</ButtonBack>
 
         <div className="bg-surface rounded-xl border p-6 space-y-6">
           {/* Header */}

--- a/src/features/candidate/pages/CVDetailPage.tsx
+++ b/src/features/candidate/pages/CVDetailPage.tsx
@@ -8,8 +8,9 @@ import { useGetCV } from "../hooks/useGetCV";
 import { useDownloadCV } from "../hooks/useDownloadCV";
 import { useAnalyzeCV } from "@/features/ai/hooks/useAnalyzeCV";
 import { useAnalysisResult } from "@/features/ai/hooks/useAnalysisResult";
-import { ChevronLeft, Download, RefreshCw, Loader2 } from "lucide-react";
+import { Download, RefreshCw, Loader2 } from "lucide-react";
 import { CV_STATUS } from "../types/cv.types";
+import { ButtonBack } from "@/shared/components/ui/ButtonBack";
 
 export const CVDetailPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -44,8 +45,7 @@ export const CVDetailPage = () => {
     return (
       <Section>
         <Container className="text-center">
-          <h2 className="text-2xl font-bold mb-4">Không tìm thấy CV</h2>
-          <Button onClick={() => navigate(-1)}>Quay lại</Button>
+          <ButtonBack animation="bounce">Quay lại</ButtonBack>
         </Container>
       </Section>
     );
@@ -54,22 +54,7 @@ export const CVDetailPage = () => {
   return (
     <Section>
       <Container>
-        {/* Hero Section - Sticky với background thụt vào */}
-        <div className="sticky top-0 z-10">
-          <div className="flex justify-center">
-            <div className="w-full shadow-md">
-              <div className="py-4">
-                <button
-                  onClick={() => navigate(-1)}
-                  className="group flex items-center text-sm text-gray-500 hover:text-primary transition-colors cursor-pointer"
-                >
-                  <ChevronLeft className="w-4 h-4 mr-1 group-hover:-translate-x-0.5 transition-transform" />
-                  Quay lại danh sách
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ButtonBack>Quay lại danh sách</ButtonBack>
 
         <div className="bg-surface rounded-xl border border-border p-6 mt-3 shadow-sm transition-all hover:shadow-md">
           {/* Header */}

--- a/src/features/candidate/pages/JobsSuggestPage.tsx
+++ b/src/features/candidate/pages/JobsSuggestPage.tsx
@@ -8,6 +8,7 @@ import { useGetCV } from "../hooks/useGetCV";
 import { useMatchingJobsForCV } from "@/features/ai/hooks/useMatchingJobsForCV";
 import { MatchedJobCard } from "@/features/jobs/components/MatchedJobCard";
 import { useState } from "react";
+import { ButtonBack } from "@/shared/components/ui/ButtonBack";
 
 // Định nghĩa type cho filter
 type SuggestFilter = {
@@ -55,6 +56,7 @@ export const JobSuggestPage = () => {
   return (
     <Section>
       <Container>
+        <ButtonBack className="!mb-5">Quay lại chi tiết</ButtonBack>
         <div className="mb-6">
           <h1 className="text-2xl font-bold">Đề xuất việc làm phù hợp</h1>
           {cv && (

--- a/src/features/candidate/pages/MatchingJobPage.tsx
+++ b/src/features/candidate/pages/MatchingJobPage.tsx
@@ -12,6 +12,7 @@ import type { JobListItem, EmploymentTypeLabel, ExperienceLevelLabel } from "@/f
 import { EMPLOYMENT_TYPE, EXPERIENCE_LEVEL } from "@/features/jobs/types/job.types";
 import { useMemo, useState } from "react";
 import { ChevronLeft } from "lucide-react";
+import { ButtonBack } from "@/shared/components/ui/ButtonBack";
 
 // Định nghĩa type cho filter riêng
 type HistoryFilter = {
@@ -94,22 +95,7 @@ export const MatchingJobsPage = () => {
   return (
     <Section>
       <Container>
-        {/* Hero Section - Sticky với background thụt vào */}
-        <div className="sticky top-0 z-10">
-          <div className="flex justify-center">
-            <div className="w-full shadow-md">
-              <div className="py-4">
-                <button
-                  onClick={() => navigate(-1)}
-                  className="group flex items-center text-sm text-gray-500 hover:text-primary transition-colors cursor-pointer"
-                >
-                  <ChevronLeft className="w-4 h-4 mr-1 group-hover:-translate-x-0.5 transition-transform" />
-                  Quay lại chi tiết
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ButtonBack>Quay lại chi tiết</ButtonBack>
 
         <div className="mb-6 mt-6">
           <h1 className="text-2xl font-bold text-gray-900">Việc làm phù hợp với CV</h1>

--- a/src/features/jobs/pages/JobDetailPage.tsx
+++ b/src/features/jobs/pages/JobDetailPage.tsx
@@ -34,6 +34,7 @@ import { MatchCVButton } from "@/features/ai/components/MatchCVButton";
 import { ApplySection } from "@/features/applications/components/ApplySection";
 import { useGetSimilarJobs } from "../hooks/useGetSimilarJobs";
 import { JobCard } from "../components/JobCard";
+import { ButtonBack } from "@/shared/components/ui/ButtonBack";
 
 const JobDetailPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -79,9 +80,7 @@ const JobDetailPage = () => {
             <p className="text-text-secondary mb-8">
               Công việc bạn đang tìm kiếm không tồn tại hoặc đã bị xóa.
             </p>
-            <Button onClick={() => navigate(-1)}>
-              <ChevronLeft className="w-4 h-4 mr-2" /> Quay lại
-            </Button>
+            <ButtonBack animation="bounce">Quay lại</ButtonBack>
           </div>
         </Container>
       </Section>

--- a/src/index.css
+++ b/src/index.css
@@ -21,16 +21,21 @@
   --color-secondary-foreground: #ffffff;
 
   /* ===== BACKGROUND ===== */
-  --color-background: #f9fafb; /* gray-50 */
+  --color-background: #f9fafb;
+  /* gray-50 */
   --color-surface: #ffffff;
 
   /* ===== TEXT ===== */
-  --color-text-primary: #111827; /* gray-900 */
-  --color-text-secondary: #6b7280; /* gray-500 */
-  --color-text-muted: #9ca3af; /* gray-400 */
+  --color-text-primary: #111827;
+  /* gray-900 */
+  --color-text-secondary: #6b7280;
+  /* gray-500 */
+  --color-text-muted: #9ca3af;
+  /* gray-400 */
 
   /* ===== BORDER ===== */
-  --color-border: oklch(87.2% 0.01 258.338); /* gray-200 */
+  --color-border: oklch(87.2% 0.01 258.338);
+  /* gray-200 */
 
   /* ===== STATE COLORS ===== */
   --color-success: #16a34a;
@@ -62,7 +67,51 @@
   p {
     @apply text-base leading-relaxed;
   }
+
   .menu-item {
     @apply px-3 py-2 text-sm rounded-md cursor-pointer text-text-primary hover:bg-primary/10 focus:outline-none;
+  }
+}
+
+
+
+/* global.css hoặc index.css */
+@keyframes bounce {
+
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  50% {
+    transform: translateX(-4px);
+  }
+}
+
+@keyframes shake {
+
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  25% {
+    transform: translateX(-3px);
+  }
+
+  75% {
+    transform: translateX(3px);
+  }
+}
+
+@keyframes ripple {
+  0% {
+    transform: scale(0);
+    opacity: 0.5;
+  }
+
+  100% {
+    transform: scale(4);
+    opacity: 0;
   }
 }

--- a/src/shared/components/ui/ButtonBack.tsx
+++ b/src/shared/components/ui/ButtonBack.tsx
@@ -1,0 +1,128 @@
+// shared/components/ui/ButtonBack.tsx
+import { useNavigate } from "react-router-dom";
+import { ChevronLeft, ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes } from "react";
+
+interface ButtonBackProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    className?: string;
+    children?: React.ReactNode;
+    variant?: "default" | "outline" | "ghost" | "primary";
+    size?: "sm" | "md" | "lg" | "xl";
+    icon?: React.ReactNode;
+    iconPosition?: "left" | "right";
+    showText?: boolean;
+    fallbackPath?: string;
+    onBack?: () => void;
+    animation?: "none" | "slide" | "bounce" | "fade" | "scale" | "glow" | "shake";
+}
+
+export const ButtonBack = forwardRef<HTMLButtonElement, ButtonBackProps>(({
+    className,
+    children,
+    variant = "default",
+    size = "md",
+    icon,
+    iconPosition = "left",
+    showText = true,
+    fallbackPath = "/",
+    onBack,
+    disabled,
+    animation = "slide",
+    ...props
+}, ref) => {
+    const navigate = useNavigate();
+
+    const handleBack = () => {
+        if (onBack) {
+            onBack();
+        } else {
+            if (window.history.length > 1) {
+                navigate(-1);
+            } else {
+                navigate(fallbackPath);
+            }
+        }
+    };
+
+    const variants = {
+        default: "text-text-secondary hover:text-primary bg-transparent",
+        outline: "px-3 py-1.5 border border-gray-300 rounded-lg hover:border-primary hover:text-primary hover:bg-primary/5 bg-transparent",
+        ghost: "hover:bg-gray-100 px-2 py-1 rounded bg-transparent",
+        primary: "px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 shadow-sm hover:shadow-md"
+    };
+
+    const sizes = {
+        sm: "text-xs gap-1",
+        md: "text-sm gap-2",
+        lg: "text-base gap-2",
+        xl: "text-lg gap-3"
+    };
+
+    const iconSizes = {
+        sm: "w-3 h-3",
+        md: "w-4 h-4",
+        lg: "w-5 h-5",
+        xl: "w-6 h-6"
+    };
+
+    // Animation classes với keyframes
+    const animations = {
+        none: "",
+        slide: "hover:translate-x-[-4px] transition-transform duration-300 ease-out",
+        bounce: "hover:animate-[bounce_0.5s_ease]",
+        fade: "hover:opacity-70 transition-opacity duration-300",
+        scale: "hover:scale-105 transition-transform duration-300 ease-out active:scale-95",
+        glow: "hover:shadow-[0_0_10px_rgba(59,130,246,0.5)] hover:border-primary/50 transition-all duration-300",
+        shake: "hover:animate-[shake_0.3s_ease-in-out]"
+    };
+
+    const iconAnimations = {
+        none: "",
+        slide: "group-hover:translate-x-[-2px] transition-transform duration-300",
+        bounce: "group-hover:animate-[bounce_0.5s_ease]",
+        fade: "group-hover:opacity-70 transition-opacity duration-300",
+        scale: "group-hover:scale-110 transition-transform duration-300",
+        glow: "group-hover:drop-shadow-[0_0_3px_rgba(59,130,246,0.5)] transition-all duration-300",
+        shake: "group-hover:animate-[shake_0.3s_ease-in-out]"
+    };
+
+    const defaultIcon = variant === "primary" ?
+        <ArrowLeft className={cn(iconSizes[size], iconAnimations[animation])} /> :
+        <ChevronLeft className={cn(iconSizes[size], iconAnimations[animation])} />;
+
+    const content = (
+        <>
+            {iconPosition === "left" && (icon || defaultIcon)}
+            {showText && (children !== undefined ? children : (variant === "default" ? "Quay lại" : "Back"))}
+            {iconPosition === "right" && (icon || defaultIcon)}
+        </>
+    );
+
+    return (
+        <button
+            ref={ref}
+            onClick={handleBack}
+            disabled={disabled}
+            className={cn(
+                "group relative inline-flex items-center transition-all duration-200 font-medium overflow-hidden",
+                "focus:outline-none focus:ring-2 focus:ring-primary/50 focus:ring-offset-1 cursor-pointer",
+                "disabled:opacity-50 disabled:cursor-not-allowed",
+                variants[variant],
+                sizes[size],
+                animations[animation],
+                className
+            )}
+            {...props}
+        >
+            {/* Ripple effect khi click */}
+            <span className="absolute inset-0 overflow-hidden">
+                <span className="absolute inset-0 opacity-0 group-active:opacity-100 group-active:animate-[ripple_0.4s_ease-out] bg-white/20 rounded-full" />
+            </span>
+            {content}
+        </button>
+    );
+});
+
+ButtonBack.displayName = "ButtonBack";


### PR DESCRIPTION
- Create reusable ButtonBack component in shared/ui
- Support variants: default, outline, ghost, primary
- Support sizes: sm, md, lg, xl
- Add fallback path when history is empty
- Add onBack callback support
- Replace back buttons in MyApplicationsPage
- Replace back buttons in ApplicationDetailPage
- Replace back buttons in CVManagementPage
- Replace back buttons in ProfilePage
- Remove duplicate back button implementations

Components updated:
- MyApplicationsPage
- ApplicationDetailPage
- CVManagementPage
- CVDetailPage
- ProfilePage
- JobDetailPage