### PR TITLE
hotfix: improve ProvinceSelect UX and fix focus issues

### DIFF
--- a/src/features/geocoding/components/ProvinceSelect.tsx
+++ b/src/features/geocoding/components/ProvinceSelect.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import { useProvinceSelect } from "../hooks/useProvinceSelect";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 type Props = {
   label?: string;
@@ -17,15 +17,32 @@ export const ProvinceSelect = ({
 }: Props) => {
   const { provinces, loading, selectedName, handleChange, clear, search, setSearch } = useProvinceSelect({ value, onChange });
   const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const displayValue = search || selectedName || "";
 
+  // Click outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Kiểm tra có nên hiện dropdown không
+  const shouldShowDropdown = isOpen && (search?.length > 0 || loading);
+
   return (
-    <div className="w-full relative">
+    <div className="w-full relative" ref={wrapperRef}>
       {label && <label className="block text-sm font-medium mb-1">{label}</label>}
 
       <div className={cn("flex items-center border rounded-lg px-3 py-2", error && "border-red-500")}>
         <input
+          ref={inputRef}
           type="text"
           value={displayValue}
           onChange={(e) => {
@@ -36,33 +53,45 @@ export const ProvinceSelect = ({
           onFocus={() => setIsOpen(true)}
           placeholder="Nhập tên tỉnh/thành phố..."
           className="flex-1 outline-none bg-transparent text-sm"
-          disabled={loading}
         />
         {displayValue && (
-          <button type="button" onClick={clear} className="ml-2 text-gray-400 hover:text-red-500">
+          <button
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              clear();
+              inputRef.current?.focus();
+            }}
+            className="ml-2 text-gray-400 hover:text-red-500"
+          >
             ×
           </button>
         )}
       </div>
 
-      {isOpen && !loading && provinces.length > 0 && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
-          <div className="absolute z-20 mt-1 w-full bg-white border rounded-lg shadow-lg max-h-60 overflow-auto">
-            {provinces.map((p) => (
+      {shouldShowDropdown && (
+        <div className="absolute z-20 mt-1 w-full bg-white border rounded-lg shadow-lg max-h-60 overflow-auto">
+          {loading ? (
+            <div className="p-2 text-center text-gray-500">Đang tải...</div>
+          ) : provinces.length === 0 ? (
+            <div className="p-2 text-center text-gray-500">Không tìm thấy</div>
+          ) : (
+            provinces.map((p) => (
               <div
                 key={p.code}
                 className="px-3 py-2 cursor-pointer hover:bg-gray-100"
-                onClick={() => {
+                onMouseDown={(e) => {
+                  e.preventDefault();
                   handleChange(p.name);
                   setIsOpen(false);
+                  inputRef.current?.focus();
                 }}
               >
                 {p.name}
               </div>
-            ))}
-          </div>
-        </>
+            ))
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/features/geocoding/hooks/useProvinceSelect.ts
+++ b/src/features/geocoding/hooks/useProvinceSelect.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useCallback, useRef } from "react";
 import { geocodingApi } from "../services/geocodingApi";
 
 type Props = {
@@ -13,46 +13,38 @@ export const useProvinceSelect = ({ value, onChange }: Props = {}) => {
   const [selectedName, setSelectedName] = useState<string | null>(value ?? null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const searchProvinces = useCallback(async (keyword: string) => {
-    if (!keyword) {
-      setProvinces([]);
-      setLoading(false);
-      return;
-    }
+  // Không set loading = true ngay lập tức, để tránh re-render đột ngột
+  const handleSearchChange = useCallback((newSearch: string) => {
+    setSearch(newSearch);
 
-    setLoading(true);
-    try {
-      const data = await geocodingApi.getProvinces(keyword);
-      setProvinces(data.map(p => ({ code: p.id, name: p.name })));
-    } catch (error) {
-      console.error(error);
-      setProvinces([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  // Debounce search
-  useEffect(() => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
 
-    timeoutRef.current = setTimeout(() => {
-      searchProvinces(search);
-    }, 300);
+    if (!newSearch) {
+      setProvinces([]);
+      return;
+    }
 
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
+    // Delay 300ms mới gọi API
+    timeoutRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const data = await geocodingApi.getProvinces(newSearch);
+        setProvinces(data.map(p => ({ code: p.id, name: p.name })));
+      } catch (error) {
+        console.error(error);
+        setProvinces([]);
+      } finally {
+        setLoading(false);
       }
-    };
-  }, [search, searchProvinces]);
+    }, 300);
+  }, []);
 
   const handleChange = (name: string) => {
     setSelectedName(name);
     onChange?.(name);
-    setSearch(""); // clear search khi chọn xong
+    setSearch("");
     setProvinces([]);
   };
 
@@ -70,6 +62,6 @@ export const useProvinceSelect = ({ value, onChange }: Props = {}) => {
     handleChange,
     clear,
     search,
-    setSearch,
+    setSearch: handleSearchChange,
   };
 };


### PR DESCRIPTION
- Remove overlay that caused input focus loss
- Add click outside detection to close dropdown
- Only show dropdown when search text is not empty
- Use onMouseDown with preventDefault to keep focus on input
- Remove disabled state on input while loading
- Add ref to input for better focus management